### PR TITLE
Force client to use https

### DIFF
--- a/lib/RealestateCoNz/Api/Client.php
+++ b/lib/RealestateCoNz/Api/Client.php
@@ -286,7 +286,7 @@ class RealestateCoNz_Api_Client
         $api_signature = $this->createSignature($method->getUrl(), $method->getQueryParams(), $method->getPostParams(), $method->getRawData(), $method->getHttpAuthConcat());
 
         // build the url
-        $url = 'http://' . $this->server . '/' . $this->version . $method->getUrl();
+        $url = 'https://' . $this->server . '/' . $this->version . $method->getUrl();
 
         $query_params = array(
             'api_key' => $this->public_key


### PR DESCRIPTION
Upgrades to our infrastructure will require all clients to use HTTPS and redirect HTTP traffic to HTTPS.